### PR TITLE
Add second music track and closing petals

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ La música se reproduce de manera automática. Asegúrate de que tu navegador pe
 - `assets/js/script.js` – Código JavaScript que controla el carrusel, los mensajes y la música.
 - `assets/images/` – Fotografías que se muestran en el carrusel.
 - `assets/audio/musica.mp3` – Pista musical de fondo.
+- `assets/audio/musica2.mp3` – Se reproduce tras el carrusel de fotos.
 
 ## Publicación en GitHub Pages
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -29,6 +29,9 @@ const imageAlts = [
 ];
 let carouselIndex = 0;
 const carouselImage = document.getElementById("carouselImage");
+const music = document.getElementById("backgroundMusic");
+const petals = document.querySelectorAll(".petal");
+let petalCloseIndex = petals.length - 1;
 const duration = 60000 / imagePaths.length;
 
 function startCarousel() {
@@ -41,6 +44,10 @@ function startCarousel() {
       carouselImage.alt = imageAlts[carouselIndex];
     } else {
       clearInterval(interval);
+      music.src = "assets/audio/musica2.mp3";
+      music.play().catch(function (error) {
+        console.error("Error al reproducir la música:", error);
+      });
       document.getElementById("carouselSection").style.display = "none";
       document.getElementById("initialSection").style.display = "flex";
       document.getElementById("openButton").style.display = "block";
@@ -67,10 +74,9 @@ let currentIndex = 0;
 function bloomFlower() {
   document.getElementById("openButton").style.display = "none";
   const flower = document.getElementById("flower");
-  const petals = document.querySelectorAll(".petal");
+  petalCloseIndex = petals.length - 1;
   const center = document.querySelector(".center");
   const messageEl = document.getElementById("message");
-  const music = document.getElementById("backgroundMusic");
   music.src = "assets/audio/musica.mp3";
   music.play().catch(function(error) {
     console.error("Error al reproducir la música:", error);
@@ -99,6 +105,10 @@ function nextMessage() {
   messageEl.style.opacity = "0";
   setTimeout(() => {
     currentIndex++;
+    if (petalCloseIndex >= 0) {
+      petals[petalCloseIndex].style.opacity = "0";
+      petalCloseIndex--;
+    }
     if (currentIndex < messages.length) {
       messageEl.innerHTML = messages[currentIndex];
       messageEl.style.opacity = "1";


### PR DESCRIPTION
## Summary
- integrate `musica2.mp3` so that it plays once the photo carousel ends
- reuse the background music element across sections
- close one petal on each message advance
- note the new audio file in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686aff2e4ffc83248bbd0286786124a3