### PR TITLE
Fix puzzle drag drop retrieval

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -177,6 +177,10 @@ function initPuzzle() {
   for(let i=piecesContainer.children.length;i>=0;i--) {
     piecesContainer.appendChild(piecesContainer.children[Math.random()*i|0]);
   }
+
+  // allow dropping pieces back to the container
+  piecesContainer.addEventListener("dragover", e => e.preventDefault());
+  piecesContainer.addEventListener("drop", returnPiece);
 }
 
 function dragPiece(e) {
@@ -184,12 +188,22 @@ function dragPiece(e) {
 }
 
 function dropPiece(e) {
-  if (e.target.children.length === 0) {
+  e.preventDefault();
+  if (e.currentTarget.children.length === 0) {
     const id = e.dataTransfer.getData("text/plain");
-    const piece = piecesContainer.querySelector(`.piece[data-index='${id}']`);
-    if (piece) e.target.appendChild(piece);
-    checkPuzzle();
+    const piece = document.querySelector(`.piece[data-index='${id}']`);
+    if (piece) {
+      e.currentTarget.appendChild(piece);
+      checkPuzzle();
+    }
   }
+}
+
+function returnPiece(e) {
+  e.preventDefault();
+  const id = e.dataTransfer.getData("text/plain");
+  const piece = document.querySelector(`.piece[data-index='${id}']`);
+  if (piece) piecesContainer.appendChild(piece);
 }
 
 function checkPuzzle() {


### PR DESCRIPTION
## Summary
- allow dropping puzzle pieces back to the container
- locate puzzle pieces with `document.querySelector` so drag/drop works from board slots or pieces container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b52b844dc8324805339c9127eab4a