### PR TITLE
Add second puzzle level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Esta pequeña página web es un detalle de San Valentín. Ahora incluye una pantalla inicial donde puedes elegir entre una **Sorpresa** directa o un pequeño **Juego** de rompecabezas antes de ver la sorpresa.
 
+El juego de rompecabezas cuenta con dos niveles. Al completar el primer tablero, se muestra un segundo rompecabezas antes de revelar el mensaje final.
+Cada pieza se marca como imagen mediante atributos ARIA para que los lectores de pantalla anuncien "pieza del rompecabezas".
+
 ## Cómo abrir la página
 
 1. Clona o descarga este repositorio.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -18,7 +18,9 @@
       min-height: 100vh;
     }
     #puzzleBoard,
-    #puzzlePieces {
+    #puzzlePieces,
+    #puzzleBoard2,
+    #puzzlePieces2 {
       display: grid;
       grid-template-columns: repeat(3, 120px);
       grid-template-rows: repeat(3, 120px);
@@ -26,16 +28,21 @@
       justify-content: center;
       margin: 10px auto;
     }
-    #puzzleBoard {
+    #puzzleBoard,
+    #puzzleBoard2 {
       margin-bottom: 20px;
     }
     /* Oculta cualquier referencia de la imagen completa del rompecabezas */
-    #puzzleBoard img {
+    #puzzleBoard img,
+    #puzzleBoard2 img {
       display: none;
     }
     #puzzleBoard .slot,
     #puzzlePieces .piece,
-    #puzzleBoard .piece {
+    #puzzleBoard .piece,
+    #puzzleBoard2 .slot,
+    #puzzlePieces2 .piece,
+    #puzzleBoard2 .piece {
       width: 120px;
       height: 120px;
       border: 1px solid #fff;
@@ -43,10 +50,12 @@
       border-radius: 10px;
       box-shadow: 0 2px 4px rgba(0,0,0,0.3);
     }
-    #puzzleBoard .slot {
+    #puzzleBoard .slot,
+    #puzzleBoard2 .slot {
       background-color: rgba(255, 255, 255, 0.2);
     }
-    #puzzlePieces .piece {
+    #puzzlePieces .piece,
+    #puzzlePieces2 .piece {
       cursor: move;
     }
     #pantalla-inicio .btn {

--- a/assets/js/puzzle.js
+++ b/assets/js/puzzle.js
@@ -4,10 +4,17 @@ const contenedorSorpresa = document.getElementById("contenedor-sorpresa");
 const contenedorJuego = document.getElementById("contenedor-juego");
 const nivel1 = document.getElementById("nivel1");
 const nivel2 = document.getElementById("nivel2");
+const nivelFinal = document.getElementById("nivelFinal");
 const piecesContainer = document.getElementById("puzzlePieces");
 const board = document.getElementById("puzzleBoard");
+const piecesContainer2 = document.getElementById("puzzlePieces2");
+const board2 = document.getElementById("puzzleBoard2");
+
+let currentBoard;
+let currentPieces;
 
 export function initPuzzle() {
+  nivelFinal.classList.add("hidden");
   nivel2.classList.add("hidden");
   nivel1.classList.remove("hidden");
   contenedorJuego.classList.remove("hidden");
@@ -15,6 +22,14 @@ export function initPuzzle() {
   pantallaInicio.style.display = "none";
   piecesContainer.innerHTML = "";
   board.innerHTML = "";
+  piecesContainer2.innerHTML = "";
+  board2.innerHTML = "";
+  currentBoard = board;
+  currentPieces = piecesContainer;
+  setupLevel(currentBoard, currentPieces, "assets/images/1.jpg");
+}
+
+function setupLevel(boardEl, piecesEl, imagePath) {
   const indices = [0,1,2,3,4,5,6,7,8].sort(() => Math.random() - 0.5);
   for (let i=0;i<9;i++) {
     const slot = document.createElement("div");
@@ -22,28 +37,26 @@ export function initPuzzle() {
     slot.dataset.index = i;
     slot.addEventListener("dragover", e=>e.preventDefault());
     slot.addEventListener("drop", dropPiece);
-    board.appendChild(slot);
+    boardEl.appendChild(slot);
 
     const pieceIndex = indices[i];
     const piece = document.createElement("div");
     piece.className = "piece";
     piece.draggable = true;
     piece.dataset.index = pieceIndex;
+    piece.setAttribute("aria-label", "pieza del rompecabezas");
     const x = (pieceIndex % 3) * -PIECE_SIZE;
     const y = Math.floor(pieceIndex / 3) * -PIECE_SIZE;
-    piece.style.backgroundImage = "url('assets/images/1.jpg')";
+    piece.style.backgroundImage = `url('${imagePath}')`;
     piece.style.backgroundPosition = `${x}px ${y}px`;
     piece.addEventListener("dragstart", dragPiece);
-    piecesContainer.appendChild(piece);
+    piecesEl.appendChild(piece);
   }
-  // shuffle pieces visually
-  for(let i=piecesContainer.children.length;i>=0;i--) {
-    piecesContainer.appendChild(piecesContainer.children[Math.random()*i|0]);
+  for(let i=piecesEl.children.length;i>=0;i--) {
+    piecesEl.appendChild(piecesEl.children[Math.random()*i|0]);
   }
-
-  // allow dropping pieces back to the container
-  piecesContainer.addEventListener("dragover", e => e.preventDefault());
-  piecesContainer.addEventListener("drop", returnPiece);
+  piecesEl.addEventListener("dragover", e => e.preventDefault());
+  piecesEl.addEventListener("drop", returnPiece);
 }
 
 export function dragPiece(e) {
@@ -54,7 +67,8 @@ export function dropPiece(e) {
   e.preventDefault();
   if (e.currentTarget.children.length === 0) {
     const id = e.dataTransfer.getData("text/plain");
-    const piece = document.querySelector(`.piece[data-index='${id}']`);
+    let piece = currentPieces.querySelector(`.piece[data-index='${id}']`);
+    if (!piece) piece = currentBoard.querySelector(`.piece[data-index='${id}']`);
     if (piece) {
       e.currentTarget.appendChild(piece);
       checkPuzzle();
@@ -65,18 +79,26 @@ export function dropPiece(e) {
 function returnPiece(e) {
   e.preventDefault();
   const id = e.dataTransfer.getData("text/plain");
-  const piece = document.querySelector(`.piece[data-index='${id}']`);
-  if (piece) piecesContainer.appendChild(piece);
+  const piece = currentBoard.querySelector(`.piece[data-index='${id}']`);
+  if (piece) currentPieces.appendChild(piece);
 }
 
 export function checkPuzzle() {
   for (let i=0;i<9;i++) {
-    const slot = board.children[i];
+    const slot = currentBoard.children[i];
     if (!slot.firstChild || slot.firstChild.dataset.index != slot.dataset.index) {
       return;
     }
   }
-  alert("¡Bien hecho!");
-  nivel1.classList.add("hidden");
-  nivel2.classList.remove("hidden");
+  if (currentBoard === board) {
+    nivel1.classList.add("hidden");
+    nivel2.classList.remove("hidden");
+    currentBoard = board2;
+    currentPieces = piecesContainer2;
+    setupLevel(currentBoard, currentPieces, "assets/images/2.jpg");
+  } else {
+    alert("¡Bien hecho!");
+    nivel2.classList.add("hidden");
+    nivelFinal.classList.remove("hidden");
+  }
 }

--- a/assets/js/puzzle.js
+++ b/assets/js/puzzle.js
@@ -29,6 +29,13 @@ export function initPuzzle() {
   setupLevel(currentBoard, currentPieces, "assets/images/1.jpg");
 }
 
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
 function setupLevel(boardEl, piecesEl, imagePath) {
   const indices = [0,1,2,3,4,5,6,7,8].sort(() => Math.random() - 0.5);
   for (let i=0;i<9;i++) {
@@ -44,6 +51,7 @@ function setupLevel(boardEl, piecesEl, imagePath) {
     piece.className = "piece";
     piece.draggable = true;
     piece.dataset.index = pieceIndex;
+    piece.setAttribute("role", "img");
     piece.setAttribute("aria-label", "pieza del rompecabezas");
     const x = (pieceIndex % 3) * -PIECE_SIZE;
     const y = Math.floor(pieceIndex / 3) * -PIECE_SIZE;
@@ -52,9 +60,9 @@ function setupLevel(boardEl, piecesEl, imagePath) {
     piece.addEventListener("dragstart", dragPiece);
     piecesEl.appendChild(piece);
   }
-  for(let i=piecesEl.children.length;i>=0;i--) {
-    piecesEl.appendChild(piecesEl.children[Math.random()*i|0]);
-  }
+  const shuffled = Array.from(piecesEl.children);
+  shuffle(shuffled);
+  shuffled.forEach(el => piecesEl.appendChild(el));
   piecesEl.addEventListener("dragover", e => e.preventDefault());
   piecesEl.addEventListener("drop", returnPiece);
 }

--- a/index.html
+++ b/index.html
@@ -82,13 +82,18 @@
   </div>
   </div> <!-- fin contenedor-sorpresa -->
 
-  <div id="contenedor-juego" class="hidden">
+  <div id="contenedor-juego" class="hidden" role="application">
     <div id="nivel1">
       <h1>Arma el rompecabezas</h1>
       <div id="puzzleBoard"></div>
       <div id="puzzlePieces"></div>
     </div>
     <div id="nivel2" class="hidden">
+      <h1>Arma el rompecabezas - Nivel 2</h1>
+      <div id="puzzleBoard2"></div>
+      <div id="puzzlePieces2"></div>
+    </div>
+    <div id="nivelFinal" class="hidden">
       <h1>¡Bien hecho!</h1>
       <button class="btn" id="verSorpresa">Ver la sorpresa 💕</button>
     </div>


### PR DESCRIPTION
## Summary
- create level 2 puzzle section and final stage
- extend puzzle styles for second board
- implement second level logic in puzzle.js

## Testing
- `npm --version`
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_686b6095dbc88324851b95e2fd26b2be